### PR TITLE
Do not load plone.app.referenceablebehavior.testing on package registration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Do not load ``plone.app.referenceablebehavior.testing`` on package registration as it adds a broken dependency to plone.app.testing.
+  [hvelarde]
 
 
 0.7.6 (2016-11-09)

--- a/plone/app/referenceablebehavior/__init__.py
+++ b/plone/app/referenceablebehavior/__init__.py
@@ -11,7 +11,6 @@ def initialize(context):
         from Products.CMFCore import utils
         from Products.CMFCore import permissions
         from Products.Archetypes.ArchetypeTool import process_types, listTypes
-        import plone.app.referenceablebehavior.testing
 
         content_types, constructors, ftis = process_types(
             listTypes(PKG_NAME), PKG_NAME)


### PR DESCRIPTION
It adds a broken dependency to `plone.app.testing`:

```python
2016-11-10 11:27:05 ERROR Application Couldn't install plone.app.referenceablebehavior
Traceback (most recent call last):
  File "/home/hvelarde/.buildout/eggs/Zope2-2.13.24-py2.7.egg/OFS/Application.py", line 723, in install_package
    init_func(newContext)
  File "/home/hvelarde/.buildout/eggs/plone.app.referenceablebehavior-0.7.5-py2.7.egg/plone/app/referenceablebehavior/__init__.py", line 13, in initialize
    import plone.app.referenceablebehavior.testing
  File "/home/hvelarde/.buildout/eggs/plone.app.referenceablebehavior-0.7.5-py2.7.egg/plone/app/referenceablebehavior/testing.py", line 6, in <module>
    from plone.app.testing import layers
ImportError: No module named testing
```

Refs. bed1beed6e96c5a5366e5744d6eb3e03776929af

CC @tomgross 