### PR TITLE
Prevent installation on Python 3, where we know Archetypes does not work

### DIFF
--- a/news/3330.bugfix
+++ b/news/3330.bugfix
@@ -1,0 +1,2 @@
+Prevent installation on Python 3, as we know Archetypes does not work there.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,13 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup, find_packages
 
+import sys
+
+
+if sys.version_info[0] != 2:
+    # Prevent creating or installing a distribution with Python 3.
+    raise ValueError("plone.app.referenceablebehavior is based on Archetypes, which is Python 2 only.")
+
 version = '0.7.9.dev0'
 
 setup(
@@ -34,6 +41,7 @@ setup(
     namespace_packages=['plone', 'plone.app'],
     include_package_data=True,
     zip_safe=False,
+    python_requires='==2.7.*',
     install_requires=[
         'setuptools',
         'plone.app.locales >= 4.3.9',


### PR DESCRIPTION
See https://github.com/plone/Products.CMFPlone/issues/3330